### PR TITLE
Restrict formation assignments to known positions

### DIFF
--- a/main.py
+++ b/main.py
@@ -221,14 +221,15 @@ def best_xi_for_formation(df, positions):
             break
         candidates = remaining[remaining['Position Selected'].str.contains(pos, na=False)]
         if candidates.empty:
-            candidates = remaining
+            rows.append({'Position': pos, 'Name': 'None', 'Score': 0})
+            continue
         candidates = candidates.copy()
         candidates['Score'] = candidates.apply(lambda r: player_position_score(r, pos), axis=1)
         best = candidates.sort_values('Score', ascending=False).iloc[0]
         rows.append({'Position': pos, 'Name': best['Name'], 'Score': round(best['Score'], 2)})
         used.add(best['Name'])
         total += best['Score']
-    avg = total / len(rows) if rows else 0
+    avg = total / len(positions) if positions else 0
     return pd.DataFrame(rows), avg
 
 


### PR DESCRIPTION
## Summary
- Ensure best XI selection only assigns players to positions listed in their squad info
- Mark unfilled formation slots and penalize missing positions when calculating scores

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68bcc714971c832c8a626e642fdadbae