### PR TITLE
Add squad assessment via ChatGPT

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A minimalistic Python tool for displaying Football Manager 2024 squad data expor
 - Rate common formations and all official tactical styles on a 1-100 scale
 - Tabs highlighting the best, worst, and wonderkid players in the squad
 - Position scoring uses weighted attributes based on FM-Arena testing
+- "Assess My Squad" button that sends your squad data to ChatGPT for a written assessment
 
 
 ## Installation
@@ -18,9 +19,12 @@ pip install -r requirements.txt
 
 ## Usage
 ```
+export OPENAI_API_KEY=your_api_key
 python main.py
 ```
 Then click **Open Squad HTML** and choose an exported FM24 squad HTML file.
+
+Use **Assess My Squad** to generate a summary of strengths, weak spots, and players to consider offloading.
 
 Analysis tabs will populate once the file is loaded.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 PyQt5
 pandas
+openai


### PR DESCRIPTION
## Summary
- Add "Assess My Squad" button that sends squad data to ChatGPT and displays a text assessment
- Integrate OpenAI client and update dependencies
- Document ChatGPT feature and API key requirement in README

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68bcd687f514832cb1778e18adb50712