### PR TITLE
Add settings dialog for OpenAI API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,11 @@ pip install -r requirements.txt
 
 ## Usage
 ```
-export OPENAI_API_KEY=your_api_key
 python main.py
 ```
 Then click **Open Squad HTML** and choose an exported FM24 squad HTML file.
+
+For squad assessments via ChatGPT, supply your OpenAI API key either by setting the `OPENAI_API_KEY` environment variable before launch or by clicking the ⚙ settings icon within the app and entering the key.
 
 Use **Assess My Squad** to generate a summary of strengths, weak spots, and players to consider offloading.
 


### PR DESCRIPTION
## Summary
- Add a settings button to the title bar to capture the user's OpenAI API key.
- Store the entered key and use it when generating squad assessments.
- Update documentation to describe entering the API key via the new settings icon.

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68bcd9815dc8832c8253225d04b9223f