### PR TITLE
Use cost-effective gpt-4o-mini model

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A minimalistic Python tool for displaying Football Manager 2024 squad data expor
 - Rate common formations and all official tactical styles on a 1-100 scale
 - Tabs highlighting the best, worst, and wonderkid players in the squad
 - Position scoring uses weighted attributes based on FM-Arena testing
-- "Assess My Squad" button that sends your squad data to ChatGPT for a written assessment
+- "Assess My Squad" button that sends your squad data to ChatGPT's cost-effective `gpt-4o-mini` model for a written assessment
 
 
 ## Installation
@@ -23,7 +23,7 @@ python main.py
 ```
 Then click **Open Squad HTML** and choose an exported FM24 squad HTML file.
 
-For squad assessments via ChatGPT, supply your OpenAI API key either by setting the `OPENAI_API_KEY` environment variable before launch or by clicking the ⚙ settings icon within the app and entering the key.
+For squad assessments via ChatGPT's `gpt-4o-mini` model, supply your OpenAI API key either by setting the `OPENAI_API_KEY` environment variable before launch or by clicking the ⚙ settings icon within the app and entering the key.
 
 Use **Assess My Squad** to generate a summary of strengths, weak spots, and players to consider offloading.
 

--- a/main.py
+++ b/main.py
@@ -20,6 +20,9 @@ from PyQt5.QtWidgets import (
 )
 from openai import OpenAI
 
+
+DEFAULT_MODEL = "gpt-4o-mini"
+
 class FM24Tool(QWidget):
     def __init__(self):
         super().__init__()
@@ -278,7 +281,7 @@ class FM24Tool(QWidget):
         try:
             client = OpenAI(api_key=self.api_key) if self.api_key else OpenAI()
             response = client.chat.completions.create(
-                model="gpt-4o-mini",
+                model=DEFAULT_MODEL,
                 messages=[
                     {"role": "system", "content": prompt},
                     {"role": "user", "content": str(summary)},


### PR DESCRIPTION
## Summary
- centralize the OpenAI model in a `DEFAULT_MODEL` constant using the budget-friendly `gpt-4o-mini` model
- document the default ChatGPT model in README for clarity

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68bd8a2ef048832c8bb27773a238a4c2